### PR TITLE
demo integrate snow

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -31,64 +31,66 @@ class HappyIntegration {
 //   }
 // }
 
-Sentry.init({
-    // Client's DSN.
-    dsn: 'https://363a337c11a64611be4845ad6e24f3ac@sentry.io/297378',
-    // An array of strings or regexps that'll be used to ignore specific errors based on their type/message
-    ignoreErrors: [/PickleRick_\d\d/, 'RangeError'],
-    // An array of strings or regexps that'll be used to ignore specific errors based on their origin url
-    denyUrls: ['external-lib.js'],
-    // An array of strings or regexps that'll be used to allow specific errors based on their origin url
-    // allowUrls: ['http://localhost:5000', 'https://browser.sentry-cdn'],
-    // Debug mode with valuable initialization/lifecycle informations.
-    debug: true,
-    // Whether SDK should be enabled or not.
-    enabled: true,
-    // Custom integrations callback
-    integrations(integrations) {
-        return [new HappyIntegration(), ...integrations];
-    },
-    // A release identifier.
-    release: '1537345109360',
-    // An environment identifier.
-    environment: 'staging',
-    // Custom event transport that will be used to send things to Sentry
-    // transport: HappyTransport,
-    // Method called for every captured event
-    async beforeSend(event, hint) {
-        // Because beforeSend and beforeBreadcrumb are async, user can fetch some data
-        // return a promise, or whatever he wants
-        // Our CustomError defined in errors.js has `someMethodAttachedToOurCustomError`
-        // which can mimick something like a network request to grab more detailed error info or something.
-        // hint is original exception that was triggered, so we check for our CustomError name
-        if (hint.originalException.name === 'CustomError') {
-            const serverData = await hint.originalException.someMethodAttachedToOurCustomError();
-            event.extra = {
-                ...event.extra,
-                serverData,
-            };
-        }
-        console.log(event);
-        return event;
-    },
-    // Method called for every captured breadcrumb
-    beforeBreadcrumb(breadcrumb, hint) {
-        // We ignore our own logger and rest of the buttons just for presentation purposes
-        if (breadcrumb.message.startsWith('Sentry Logger')) return null;
-        if (breadcrumb.category !== 'ui.click' || hint.event.target.id !== 'breadcrumb-hint') return null;
-
-        // If we have a `ui.click` type of breadcrumb, eg. clicking on a button we defined in index.html
-        // We will extract a `data-label` attribute from it and use it as a part of the message
-        if (breadcrumb.category === 'ui.click') {
-            const label = hint.event.target.dataset.label;
-            if (label) {
-                breadcrumb.message = `User clicked on a button with label "${label}"`;
+SNOW(win => {
+    Sentry.init({
+        // Client's DSN.
+        dsn: 'https://363a337c11a64611be4845ad6e24f3ac@sentry.io/297378',
+        // An array of strings or regexps that'll be used to ignore specific errors based on their type/message
+        ignoreErrors: [/PickleRick_\d\d/, 'RangeError'],
+        // An array of strings or regexps that'll be used to ignore specific errors based on their origin url
+        denyUrls: ['external-lib.js'],
+        // An array of strings or regexps that'll be used to allow specific errors based on their origin url
+        // allowUrls: ['http://localhost:5000', 'https://browser.sentry-cdn'],
+        // Debug mode with valuable initialization/lifecycle informations.
+        debug: true,
+        // Whether SDK should be enabled or not.
+        enabled: true,
+        // Custom integrations callback
+        integrations(integrations) {
+            return [new HappyIntegration(), ...integrations];
+        },
+        // A release identifier.
+        release: '1537345109360',
+        // An environment identifier.
+        environment: 'staging',
+        // Custom event transport that will be used to send things to Sentry
+        // transport: HappyTransport,
+        // Method called for every captured event
+        async beforeSend(event, hint) {
+            // Because beforeSend and beforeBreadcrumb are async, user can fetch some data
+            // return a promise, or whatever he wants
+            // Our CustomError defined in errors.js has `someMethodAttachedToOurCustomError`
+            // which can mimick something like a network request to grab more detailed error info or something.
+            // hint is original exception that was triggered, so we check for our CustomError name
+            if (hint.originalException.name === 'CustomError') {
+                const serverData = await hint.originalException.someMethodAttachedToOurCustomError();
+                event.extra = {
+                    ...event.extra,
+                    serverData,
+                };
             }
-        }
-        console.log(breadcrumb);
-        return breadcrumb;
-    },
-});
+            console.log(event);
+            return event;
+        },
+        // Method called for every captured breadcrumb
+        beforeBreadcrumb(breadcrumb, hint) {
+            // We ignore our own logger and rest of the buttons just for presentation purposes
+            if (breadcrumb.message.startsWith('Sentry Logger')) return null;
+            if (breadcrumb.category !== 'ui.click' || hint.event.target.id !== 'breadcrumb-hint') return null;
+
+            // If we have a `ui.click` type of breadcrumb, eg. clicking on a button we defined in index.html
+            // We will extract a `data-label` attribute from it and use it as a part of the message
+            if (breadcrumb.category === 'ui.click') {
+                const label = hint.event.target.dataset.label;
+                if (label) {
+                    breadcrumb.message = `User clicked on a button with label "${label}"`;
+                }
+            }
+            console.log(breadcrumb);
+            return breadcrumb;
+        },
+    }, win);
+})
 
 // Testing code, irrelevant vvvvv
 
@@ -110,15 +112,27 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.querySelector('#ignore-message').addEventListener('click', () => {
-        throw new Error('Exception that will be ignored because of this keyword => PickleRick_42 <=');
+        function x(w) {
+            throw new w.Error('Exception that will be ignored because of this keyword => PickleRick_42 <=');
+        }
+        setTimeout(x, 100, top);
+        setTimeout(x, 100, window[0]);
     });
 
     document.querySelector('#ignore-type').addEventListener('click', () => {
-        throw new RangeError("Exception that will be ignored because of it's type");
+        function x(w) {
+            throw new w.RangeError("Exception that will be ignored because of it's type");
+        }
+        setTimeout(x, 100, top);
+        setTimeout(x, 100, window[0]);
     });
 
     document.querySelector('#regular-exception').addEventListener('click', () => {
-        throw new Error(`Regular exception no. ${Date.now()}`);
+        function x(w) {
+            throw new w.Error(`Regular exception no. ${Date.now()}`);
+        }
+        setTimeout(x, 100, top);
+        setTimeout(x, 100, window[0]);
     });
 
     document.querySelector('#capture-exception').addEventListener('click', () => {

--- a/examples/bundle.js
+++ b/examples/bundle.js
@@ -1,6 +1,8 @@
 /*! @sentry/browser 7.34.0 (d33b88c41) | https://github.com/getsentry/sentry-javascript */
 var Sentry = (function (exports) {
 
+    let WINDOW = top;
+
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const objectToString = Object.prototype.toString;
 
@@ -226,7 +228,7 @@ var Sentry = (function (exports) {
      * @deprecated Use GLOBAL_OBJ instead or WINDOW from @sentry/browser. This will be removed in v8
      */
     function getGlobalObject() {
-        return GLOBAL_OBJ;
+        return WINDOW;
     }
 
     /**
@@ -5645,8 +5647,6 @@ var Sentry = (function (exports) {
         InboundFilters: InboundFilters
     });
 
-    const WINDOW = GLOBAL_OBJ;
-
     let ignoreOnError = 0;
 
     /**
@@ -7802,7 +7802,8 @@ var Sentry = (function (exports) {
      *
      * @see {@link BrowserOptions} for documentation on configuration options.
      */
-    function init(options = {}) {
+    function init(options = {}, win = window) {
+        WINDOW = win;
         if (options.defaultIntegrations === undefined) {
             options.defaultIntegrations = defaultIntegrations;
         }

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <title>@sentry/browser SDK examples</title>
+    <script src="https://unpkg.com/@lavamoat/snow/snow.prod.js"></script>
     <script src="bundle.js"></script>
     <script src="app.js"></script>
     <style>
@@ -20,6 +21,7 @@
     </style>
 </head>
 <body>
+<iframe></iframe>
 <button id="deny-url">denyUrls example</button>
 <button id="allow-url">allowUrls example</button>
 <button id="ignore-message">ignoreError message example</button>

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <title>@sentry/browser SDK examples</title>
-    <script src="https://unpkg.com/@lavamoat/snow/snow.prod.js"></script>
+    <script src="https://unpkg.com/@lavamoat/snow/snow.js"></script>
     <script src="bundle.js"></script>
     <script src="app.js"></script>
     <style>
@@ -21,7 +21,8 @@
     </style>
 </head>
 <body>
-<iframe></iframe>
+<div id="xxx"></div>
+<script>xxx.innerHTML='<iframe></iframe>'</script>
 <button id="deny-url">denyUrls example</button>
 <button id="allow-url">allowUrls example</button>
 <button id="ignore-message">ignoreError message example</button>


### PR DESCRIPTION
a simple demo of how minor modifications (PoC only) to sentry can enhance its capabilities to track iframes as well as the top origin:

* app.js
  * [line34](https://github.com/weizman/sentry-snow-integration-demo/pull/1/files#diff-37a0ca7ca295573e5665858b4bda191462ed214ad9e4892e098c0f43bb36cbf0L34) - wrap the call to `Sentry.init` with SNOW to call it with every new iframe in the page (change seems big but in fact the `Sentry.init` options did not change at all, only the SNOW wrap was added along with the new 2nd arg `win`)
  * [line113](https://github.com/weizman/sentry-snow-integration-demo/pull/1/files#diff-37a0ca7ca295573e5665858b4bda191462ed214ad9e4892e098c0f43bb36cbf0L113) - change exception buttons to throw both in `top` and in `iframe`
* bundle.js (diff is very small even though file is big)
  * minor changes to allow Sentry to support changing `window`s (real modification will probably be more complexed than that)
* index.html
  * create an iframe for demo purposes
  * include SNOW logic in the page